### PR TITLE
Enhance Cucumber reporting in build.gradle and TestRunner: add Allure…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'io.qameta.allure' version '2.11.2'
 }
 
 group = 'org.example'
@@ -16,6 +17,7 @@ dependencies {
     // Cucumber dependencies para JUnit 4
     testImplementation 'io.cucumber:cucumber-java:7.18.1'
     testImplementation 'io.cucumber:cucumber-junit:7.18.1'
+    testImplementation 'io.qameta.allure:allure-cucumber7-jvm:2.24.0'
 
     // Selenium
     implementation 'org.seleniumhq.selenium:selenium-java:4.22.0'
@@ -53,4 +55,15 @@ task cucumber(type: Test) {
     systemProperty 'browser', System.getProperty('browser', 'chrome')
     systemProperty 'headless', System.getProperty('headless', 'true')
     systemProperty 'cucumber.ansi-colors.disabled', 'true'
+}
+
+allure {
+    adapter {
+        aspectjWeaver.set(true)
+        frameworks {
+            cucumber7 {
+                adapterVersion.set('2.34.1')
+            }
+        }
+    }
 }

--- a/src/test/java/runner/TestRunner.java
+++ b/src/test/java/runner/TestRunner.java
@@ -9,12 +9,11 @@ import org.junit.runner.RunWith;
         features = "src/test/resources/features",
         glue = "steps",
         plugin = {
-                "pretty:build/reports/cucumber-pretty.txt",  // Sin colores
-                "html:build/reports/cucumber.html",
-                "json:build/reports/cucumber.json",
+                "pretty",
+                "io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm",
                 "junit:build/test-results/test/cucumber.xml"
         },
-        monochrome = true,  // Importante: esto desactiva colores
+        monochrome = true,
         tags = "@Regression"
 )
 public class TestRunner {


### PR DESCRIPTION
This pull request updates the `TestRunner` configuration to improve reporting and streamline plugin usage. The most important changes include replacing outdated report plugins with Allure integration and simplifying comments.

Updates to reporting plugins:

* [`src/test/java/runner/TestRunner.java`](diffhunk://#diff-59f8563b0e80d3dc19c6c456797e40a9e2c1d85cf38386b9d5883f406d346b3bL12-R16): Replaced the older plugins (`pretty:build/reports/cucumber-pretty.txt`, `html:build/reports/cucumber.html`, and `json:build/reports/cucumber.json`) with `io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm` for enhanced reporting capabilities.

Simplification:

* [`src/test/java/runner/TestRunner.java`](diffhunk://#diff-59f8563b0e80d3dc19c6c456797e40a9e2c1d85cf38386b9d5883f406d346b3bL12-R16): Removed unnecessary comments related to color settings in the `monochrome` configuration.… dependencies and update plugin configuration for improved test result visualization.